### PR TITLE
add FindTagsAppend()

### DIFF
--- a/bool_tree/tree_v4.go
+++ b/bool_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []bool {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]bool, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []bool, nodeIndex uint) []bool {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]bool, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]bool, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]bool, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []bool, address patricia.IPv4Address) []bool {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]bool, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]bool, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/bool_tree/tree_v6_generated.go
+++ b/bool_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []bool {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]bool, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []bool, nodeIndex uint) []bool {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]bool, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]bool, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]bool, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []bool, address patricia.IPv6Address) []bool {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]bool, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]bool, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/byte_tree/tree_v4.go
+++ b/byte_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []byte {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]byte, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []byte, nodeIndex uint) []byte {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]byte, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]byte, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]byte, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []byte, address patricia.IPv4Address) []byte {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]byte, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]byte, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/byte_tree/tree_v6_generated.go
+++ b/byte_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []byte {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]byte, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []byte, nodeIndex uint) []byte {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]byte, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]byte, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]byte, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []byte, address patricia.IPv6Address) []byte {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]byte, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]byte, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/complex128_tree/tree_v4.go
+++ b/complex128_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, r
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []complex128 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]complex128, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []complex128, nodeIndex uint) []complex128 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]complex128, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]complex128, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]complex128, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []complex128, address patricia.IPv4Address) []complex128 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]complex128, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]complex128, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/complex128_tree/tree_v6_generated.go
+++ b/complex128_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, r
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []complex128 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]complex128, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []complex128, nodeIndex uint) []complex128 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]complex128, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]complex128, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]complex128, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []complex128, address patricia.IPv6Address) []complex128 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]complex128, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]complex128, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/complex64_tree/tree_v4.go
+++ b/complex64_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, re
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []complex64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]complex64, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []complex64, nodeIndex uint) []complex64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]complex64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]complex64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]complex64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []complex64, address patricia.IPv4Address) []complex64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]complex64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]complex64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/complex64_tree/tree_v6_generated.go
+++ b/complex64_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, re
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []complex64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]complex64, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []complex64, nodeIndex uint) []complex64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]complex64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]complex64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]complex64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []complex64, address patricia.IPv6Address) []complex64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]complex64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]complex64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/float32_tree/tree_v4.go
+++ b/float32_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, repl
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []float32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]float32, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []float32, nodeIndex uint) []float32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]float32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]float32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]float32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []float32, address patricia.IPv4Address) []float32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]float32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]float32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/float32_tree/tree_v6_generated.go
+++ b/float32_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, repl
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []float32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]float32, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []float32, nodeIndex uint) []float32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]float32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]float32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]float32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []float32, address patricia.IPv6Address) []float32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]float32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]float32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/float64_tree/tree_v4.go
+++ b/float64_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, repl
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []float64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]float64, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []float64, nodeIndex uint) []float64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]float64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]float64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]float64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []float64, address patricia.IPv4Address) []float64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]float64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]float64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/float64_tree/tree_v6_generated.go
+++ b/float64_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, repl
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []float64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]float64, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []float64, nodeIndex uint) []float64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]float64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]float64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]float64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []float64, address patricia.IPv6Address) []float64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]float64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]float64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int16_tree/tree_v4.go
+++ b/int16_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []int16 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int16, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []int16, nodeIndex uint) []int16 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int16, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int16, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int16, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []int16, address patricia.IPv4Address) []int16 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int16, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int16, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int16_tree/tree_v6_generated.go
+++ b/int16_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []int16 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int16, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []int16, nodeIndex uint) []int16 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int16, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int16, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int16, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []int16, address patricia.IPv6Address) []int16 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int16, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int16, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int32_tree/tree_v4.go
+++ b/int32_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []int32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int32, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []int32, nodeIndex uint) []int32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []int32, address patricia.IPv4Address) []int32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int32_tree/tree_v6_generated.go
+++ b/int32_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []int32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int32, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []int32, nodeIndex uint) []int32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []int32, address patricia.IPv6Address) []int32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int64_tree/tree_v4.go
+++ b/int64_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag int64, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []int64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int64, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []int64, nodeIndex uint) []int64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []int64, address patricia.IPv4Address) []int64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int8_tree/tree_v4.go
+++ b/int8_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []int8 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int8, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []int8, nodeIndex uint) []int8 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int8, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int8, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int8, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []int8, address patricia.IPv4Address) []int8 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int8, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int8, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int8_tree/tree_v6_generated.go
+++ b/int8_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []int8 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int8, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []int8, nodeIndex uint) []int8 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int8, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int8, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int8, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []int8, address patricia.IPv6Address) []int8 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int8, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int8, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int_tree/tree_v4.go
+++ b/int_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, replaceF
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []int {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []int, nodeIndex uint) []int {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []int, address patricia.IPv4Address) []int {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]int, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/int_tree/tree_v6_generated.go
+++ b/int_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, replaceF
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []int {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]int, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []int, nodeIndex uint) []int {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]int, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]int, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []int, address patricia.IPv6Address) []int {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]int, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]int, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/rune_tree/tree_v4.go
+++ b/rune_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []rune {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]rune, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []rune, nodeIndex uint) []rune {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]rune, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]rune, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]rune, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []rune, address patricia.IPv4Address) []rune {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]rune, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]rune, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/rune_tree/tree_v6_generated.go
+++ b/rune_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []rune {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]rune, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []rune, nodeIndex uint) []rune {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]rune, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]rune, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]rune, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []rune, address patricia.IPv6Address) []rune {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]rune, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]rune, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/string_tree/tree_v4.go
+++ b/string_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag string, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []string {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]string, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []string, nodeIndex uint) []string {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]string, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]string, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]string, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []string, address patricia.IPv4Address) []string {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]string, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]string, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/string_tree/tree_v6_generated.go
+++ b/string_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag string, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []string {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]string, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []string, nodeIndex uint) []string {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]string, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]string, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]string, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []string, address patricia.IPv6Address) []string {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]string, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]string, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/template/tree_v4.go
+++ b/template/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []GeneratedType {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]GeneratedType, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []GeneratedType, nodeIndex uint) []GeneratedType {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]GeneratedType, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]GeneratedType, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]GeneratedType, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []GeneratedType, address patricia.IPv4Address) []GeneratedType {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]GeneratedType, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]GeneratedType, error)
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/template/tree_v6_generated.go
+++ b/template/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []GeneratedType {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]GeneratedType, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []GeneratedType, nodeIndex uint) []GeneratedType {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]GeneratedType, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]GeneratedType, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]GeneratedType, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []GeneratedType, address patricia.IPv6Address) []GeneratedType {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]GeneratedType, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]GeneratedType, error)
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint16_tree/tree_v4.go
+++ b/uint16_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []uint16 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint16, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []uint16, nodeIndex uint) []uint16 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint16, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint16, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint16, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []uint16, address patricia.IPv4Address) []uint16 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint16, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint16, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint16_tree/tree_v6_generated.go
+++ b/uint16_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []uint16 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint16, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []uint16, nodeIndex uint) []uint16 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint16, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint16, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint16, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []uint16, address patricia.IPv6Address) []uint16 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint16, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint16, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint32_tree/tree_v4.go
+++ b/uint32_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []uint32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint32, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []uint32, nodeIndex uint) []uint32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []uint32, address patricia.IPv4Address) []uint32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint32_tree/tree_v6_generated.go
+++ b/uint32_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []uint32 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint32, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []uint32, nodeIndex uint) []uint32 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint32, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint32, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint32, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []uint32, address patricia.IPv6Address) []uint32 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint32, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint32, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint64_tree/tree_v4.go
+++ b/uint64_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []uint64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint64, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []uint64, nodeIndex uint) []uint64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []uint64, address patricia.IPv4Address) []uint64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint64_tree/tree_v6_generated.go
+++ b/uint64_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, repla
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []uint64 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint64, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []uint64, nodeIndex uint) []uint64 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint64, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint64, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint64, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []uint64, address patricia.IPv6Address) []uint64 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint64, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint64, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint8_tree/tree_v4.go
+++ b/uint8_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []uint8 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint8, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []uint8, nodeIndex uint) []uint8 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint8, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint8, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint8, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []uint8, address patricia.IPv4Address) []uint8 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint8, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint8, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint8_tree/tree_v6_generated.go
+++ b/uint8_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, replac
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []uint8 {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint8, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []uint8, nodeIndex uint) []uint8 {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint8, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint8, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint8, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []uint8, address patricia.IPv6Address) []uint8 {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint8, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint8, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint_tree/tree_v4.go
+++ b/uint_tree/tree_v4.go
@@ -78,19 +78,26 @@ func (t *TreeV4) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV4) tagsForNode(nodeIndex uint) []uint {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint, 0)
+	}
+}
+
+func (t *TreeV4) tagsForNodeAppend(ret []uint, nodeIndex uint) []uint {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV4) FindTagsWithFilter(address patricia.IPv4Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV4) FindTagsAppend(ret []uint, address patricia.IPv4Address) []uint {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV4) FindTags(address patricia.IPv4Address) ([]uint, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing

--- a/uint_tree/tree_v6_generated.go
+++ b/uint_tree/tree_v6_generated.go
@@ -78,19 +78,26 @@ func (t *TreeV6) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, replace
 	}
 	return ret
 }
-
 func (t *TreeV6) tagsForNode(nodeIndex uint) []uint {
-	if nodeIndex == 0 {
-		// useful for base cases where we haven't found anything
+	if ret := t.tagsForNodeAppend(nil, nodeIndex); ret != nil {
+		return ret
+	} else {
+		// NB: for compatibility with the old tagsForNode()
+		// old comment: useful for base cases where we haven't found anything
 		return make([]uint, 0)
+	}
+}
+
+func (t *TreeV6) tagsForNodeAppend(ret []uint, nodeIndex uint) []uint {
+	if nodeIndex == 0 {
+		return ret
 	}
 
 	// TODO: clean up the typing in here, between uint, uint64
 	tagCount := t.nodes[nodeIndex].TagCount
-	ret := make([]uint, tagCount)
 	key := uint64(nodeIndex) << 32
 	for i := 0; i < tagCount; i++ {
-		ret[i] = t.tags[key+uint64(i)]
+		ret = append(ret, t.tags[key+uint64(i)])
 	}
 	return ret
 }
@@ -525,19 +532,29 @@ func (t *TreeV6) FindTagsWithFilter(address patricia.IPv6Address, filterFunc Fil
 	}
 }
 
-// FindTags finds all matching tags that passes the filter function
+// FindTags finds all matching tags for given address
 func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint, error) {
+	if ret := t.FindTagsAppend(nil, address); ret != nil {
+		// NB: the nil error is for compatibility with the old FindTags()
+		return ret, nil
+	} else {
+		// NB: the alloc is for compatibility with the old FindTags()
+		return make([]uint, 0), nil
+	}
+}
+
+// FindTagsAppend finds all matching tags for given address and appends them to ret
+func (t *TreeV6) FindTagsAppend(ret []uint, address patricia.IPv6Address) []uint {
 	var matchCount uint
 	root := &t.nodes[1]
-	ret := make([]uint, 0)
 
 	if root.TagCount > 0 {
-		ret = append(ret, t.tagsForNode(1)...)
+		ret = t.tagsForNodeAppend(ret, 1)
 	}
 
 	if address.Length == 0 {
 		// caller just looking for root tags
-		return ret, nil
+		return ret
 	}
 
 	var nodeIndex uint
@@ -552,24 +569,24 @@ func (t *TreeV6) FindTags(address patricia.IPv6Address) ([]uint, error) {
 	for {
 		count++
 		if nodeIndex == 0 {
-			return ret, nil
+			return ret
 		}
 		node := &t.nodes[nodeIndex]
 
 		matchCount = node.MatchCount(address)
 		if matchCount < node.prefixLength {
 			// didn't match the entire node - we're done
-			return ret, nil
+			return ret
 		}
 
 		// matched the full node - get its tags, then chop off the bits we've already matched and continue
 		if node.TagCount > 0 {
-			ret = append(ret, t.tagsForNode(nodeIndex)...)
+			ret = t.tagsForNodeAppend(ret, nodeIndex)
 		}
 
 		if matchCount == address.Length {
 			// exact match - we're done
-			return ret, nil
+			return ret
 		}
 
 		// there's still more address - keep traversing


### PR DESCRIPTION
I suggest a FindTags() version that can minimize memory allocations, which is implemented in this PR.

The PR introduces FindTagsAppend(), which uses a destination slice instead of allocating it inside the function. The slice can be pre-allocated by the caller, and re-used between successive calls.