### PR TITLE
Add an Update method to update an existing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Go implemenation of a [patricia tree](https://en.wikipedia.org/wiki/Radix_tree
 tagging IPv4 and IPv6 addresses with CIDR bits, with a focus on producing as little garbage for the garbage collector to
 manage as possible. This allows you to tag millions of IP addresses without incurring a penalty during GC scanning.
 
-This library requires Go >= 1.18. Check version [1.1.0](https://github.com/kentik/patricia/releases/tag/v1.1.0) if you wish to use a prrio version.
+This library requires Go >= 1.18. Check version [1.1.0](https://github.com/kentik/patricia/releases/tag/v1.1.0) if you wish to use an older version.
 
 IP/CIDR tagging
 ---------------

--- a/bool_tree/tree_v4.go
+++ b/bool_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []bool, nodeIndex uint, matchTag bool, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []bool, nodeIndex uint, matchTag bool, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag bool) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(bool, bool) bool { return true },
+		func(bool) bool { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag bool, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag bool, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(bool, bool) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag bool, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag bool, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []bool {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/bool_tree/tree_v6_generated.go
+++ b/bool_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag bool, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []bool, nodeIndex uint, matchTag bool, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []bool, nodeIndex uint, matchTag bool, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag bool) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(bool, bool) bool { return true },
+		func(bool) bool { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag bool, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag bool, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(bool, bool) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag bool, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag bool, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []bool {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/bool_tree/trees.go
+++ b/bool_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload bool, val bool) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload bool) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload bool) bool
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/byte_tree/tree_v4.go
+++ b/byte_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []byte, nodeIndex uint, matchTag byte, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []byte, nodeIndex uint, matchTag byte, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag byte) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(byte, byte) bool { return true },
+		func(byte) byte { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag byte, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag byte, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(byte, byte) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag byte, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag byte, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []byte {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/byte_tree/tree_v6_generated.go
+++ b/byte_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag byte, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []byte, nodeIndex uint, matchTag byte, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []byte, nodeIndex uint, matchTag byte, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag byte) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(byte, byte) bool { return true },
+		func(byte) byte { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag byte, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag byte, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(byte, byte) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag byte, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag byte, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []byte {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/byte_tree/trees.go
+++ b/byte_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload byte, val byte) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload byte) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload byte) byte
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/complex128_tree/tree_v4.go
+++ b/complex128_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []complex128, nodeIndex uint, matchTag complex128
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []complex128, nodeIndex uint, matchTag complex128
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag complex128) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(complex128, complex128) bool { return true },
+		func(complex128) complex128 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag complex128, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag complex128, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(complex128, complex128) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag complex128, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex128, matchFunc Mat
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []complex128 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/complex128_tree/tree_v6_generated.go
+++ b/complex128_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag complex128, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []complex128, nodeIndex uint, matchTag complex128
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []complex128, nodeIndex uint, matchTag complex128
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag complex128) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(complex128, complex128) bool { return true },
+		func(complex128) complex128 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag complex128, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag complex128, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(complex128, complex128) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag complex128, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex128, matchFunc Mat
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []complex128 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/complex128_tree/trees.go
+++ b/complex128_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload complex128, val complex128) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload complex128) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload complex128) complex128
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/complex64_tree/tree_v4.go
+++ b/complex64_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []complex64, nodeIndex uint, matchTag complex64, 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []complex64, nodeIndex uint, matchTag complex64, 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag complex64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(complex64, complex64) bool { return true },
+		func(complex64) complex64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag complex64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag complex64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(complex64, complex64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag complex64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag complex64, matchFunc Matc
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []complex64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/complex64_tree/tree_v6_generated.go
+++ b/complex64_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag complex64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []complex64, nodeIndex uint, matchTag complex64, 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []complex64, nodeIndex uint, matchTag complex64, 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag complex64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(complex64, complex64) bool { return true },
+		func(complex64) complex64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag complex64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag complex64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(complex64, complex64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag complex64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag complex64, matchFunc Matc
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []complex64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/complex64_tree/trees.go
+++ b/complex64_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload complex64, val complex64) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload complex64) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload complex64) complex64
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/float32_tree/tree_v4.go
+++ b/float32_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []float32, nodeIndex uint, matchTag float32, matc
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []float32, nodeIndex uint, matchTag float32, matc
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag float32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(float32, float32) bool { return true },
+		func(float32) float32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag float32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag float32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(float32, float32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag float32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float32, matchFunc Matche
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []float32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/float32_tree/tree_v6_generated.go
+++ b/float32_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag float32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []float32, nodeIndex uint, matchTag float32, matc
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []float32, nodeIndex uint, matchTag float32, matc
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag float32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(float32, float32) bool { return true },
+		func(float32) float32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag float32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag float32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(float32, float32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag float32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float32, matchFunc Matche
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []float32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/float32_tree/trees.go
+++ b/float32_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload float32, val float32) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload float32) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload float32) float32
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/float64_tree/tree_v4.go
+++ b/float64_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []float64, nodeIndex uint, matchTag float64, matc
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []float64, nodeIndex uint, matchTag float64, matc
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag float64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(float64, float64) bool { return true },
+		func(float64) float64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag float64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag float64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(float64, float64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag float64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag float64, matchFunc Matche
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []float64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/float64_tree/tree_v6_generated.go
+++ b/float64_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag float64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []float64, nodeIndex uint, matchTag float64, matc
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []float64, nodeIndex uint, matchTag float64, matc
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag float64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(float64, float64) bool { return true },
+		func(float64) float64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag float64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag float64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(float64, float64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag float64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag float64, matchFunc Matche
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []float64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/float64_tree/trees.go
+++ b/float64_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload float64, val float64) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload float64) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload float64) float64
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/generics_tree/tree_v4.go
+++ b/generics_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4[T]) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4[T]) addTag(tag T, nodeIndex uint, matchFunc MatchesFunc[T], replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4[T]) addTag(tag T, nodeIndex uint, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4[T]) deleteTag(buf []T, nodeIndex uint, matchTag T, matchFunc Mat
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4[T]) deleteTag(buf []T, nodeIndex uint, matchTag T, matchFunc Mat
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4[T]) Set(address patricia.IPv4Address, tag T) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(T, T) bool { return true },
+		func(T) T { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4[T]) Add(address patricia.IPv4Address, tag T, matchFunc MatchesFunc[T]) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4[T]) SetOrUpdate(address patricia.IPv4Address, tag T, updateFunc UpdatesFunc[T]) (bool, int) {
+	return t.add(address, tag,
+		func(T, T) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4[T]) AddOrUpdate(address patricia.IPv4Address, tag T, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFunc[T], replaceFirst bool) (bool, int) {
+func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4[T], len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4[T]) add(address patricia.IPv4Address, tag T, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4[T]) Tags() []T {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4[T]) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4[T]) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4[T]) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/generics_tree/tree_v4_test.go
+++ b/generics_tree/tree_v4_test.go
@@ -997,6 +997,127 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, "parent", tag)
 }
 
+func TestSetOrUpdate(t *testing.T) {
+	buf := make([]string, 0)
+
+	address := ipv4FromBytes([]byte{1, 2, 3, 4}, 32)
+
+	tree := NewTreeV4[string]()
+
+	// add a parent node, just to mix things up
+	countIncreased, count := tree.Set(ipv4FromBytes([]byte{1, 2, 3, 0}, 24), "parent")
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagA",
+		func(string) string { return "tagZ" })
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+	found, tag := tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagA", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old string) string { return old + "B" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagAB", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old string) string { return old + "C" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABC", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old string) string { return old + "D" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABCD", tag)
+
+	// now delete the tag
+	delCount := tree.DeleteWithBuffer(buf, address, func(a string, b string) bool { return true }, "")
+	assert.Equal(t, 1, delCount)
+
+	// verify it's gone - should get the parent
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "parent", tag)
+}
+
+func TestAddOrUpdate(t *testing.T) {
+	buf := make([]string, 0)
+
+	address := ipv4FromBytes([]byte{1, 2, 3, 4}, 32)
+
+	tree := NewTreeV4[string]()
+
+	// add a parent node, just to mix things up
+	countIncreased, count := tree.Set(ipv4FromBytes([]byte{1, 2, 3, 0}, 24), "parent")
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagA",
+		nil,
+		func(string) string { return "tagZ" })
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+	found, tag := tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagA", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagZ",
+		func(string, string) bool { return true },
+		func(old string) string { return old + "B" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagAB", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagAB",
+		func(val1 string, val2 string) bool { return val1 == val2 },
+		func(old string) string { return old + "C" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABC", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagABCD",
+		func(val1 string, val2 string) bool { return val1 == val2 },
+		func(old string) string { return old + "Z" })
+	assert.Equal(t, 2, count)
+	assert.True(t, countIncreased)
+	found, tags := tree.FindDeepestTags(address)
+	assert.True(t, found)
+	assert.True(t, tagArraysEqual(tags, []string{"tagABC", "tagABCD"}))
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagABC",
+		func(val1 string, val2 string) bool { return val1 == val2 },
+		func(old string) string { return old + "DE" })
+	assert.Equal(t, 2, count)
+	assert.False(t, countIncreased)
+	found, tags = tree.FindDeepestTags(address)
+	assert.True(t, found)
+	assert.True(t, tagArraysEqual(tags, []string{"tagABCDE", "tagABCD"}))
+
+	// now delete the tag
+	delCount := tree.DeleteWithBuffer(buf, address, func(a string, b string) bool { return true }, "")
+	assert.Equal(t, 2, delCount)
+
+	// verify it's gone - should get the parent
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "parent", tag)
+}
+
 func TestDelete1(t *testing.T) {
 	tags := make([]string, 0)
 
@@ -1144,10 +1265,10 @@ func TestTagsMap(t *testing.T) {
 	tree := NewTreeV4[string]()
 
 	// insert tags
-	tree.addTag("tagA", 1, nil, false)
-	tree.addTag("tagB", 1, nil, false)
-	tree.addTag("tagC", 1, nil, false)
-	tree.addTag("tagD", 0, nil, false) // there's no node0, but it exists, so use it for this test
+	tree.addTag("tagA", 1, nil, nil)
+	tree.addTag("tagB", 1, nil, nil)
+	tree.addTag("tagC", 1, nil, nil)
+	tree.addTag("tagD", 0, nil, nil) // there's no node0, but it exists, so use it for this test
 
 	// verify
 	assert.Equal(t, 3, tree.nodes[1].TagCount)

--- a/generics_tree/tree_v6_generated.go
+++ b/generics_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6[T]) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6[T]) addTag(tag T, nodeIndex uint, matchFunc MatchesFunc[T], replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6[T]) addTag(tag T, nodeIndex uint, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6[T]) deleteTag(buf []T, nodeIndex uint, matchTag T, matchFunc Mat
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6[T]) deleteTag(buf []T, nodeIndex uint, matchTag T, matchFunc Mat
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6[T]) Set(address patricia.IPv6Address, tag T) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(T, T) bool { return true },
+		func(T) T { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6[T]) Add(address patricia.IPv6Address, tag T, matchFunc MatchesFunc[T]) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6[T]) SetOrUpdate(address patricia.IPv6Address, tag T, updateFunc UpdatesFunc[T]) (bool, int) {
+	return t.add(address, tag,
+		func(T, T) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6[T]) AddOrUpdate(address patricia.IPv6Address, tag T, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFunc[T], replaceFirst bool) (bool, int) {
+func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFunc[T], updateFunc UpdatesFunc[T]) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6[T], len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6[T]) add(address patricia.IPv6Address, tag T, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6[T]) Tags() []T {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6[T]) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6[T]) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6[T]) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/generics_tree/trees.go
+++ b/generics_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc[T any] func(payload T, val T) bool
 // FilterFunc[T] is called on each result to see if it belongs in the resulting set
 type FilterFunc[T any] func(payload T) bool
 
+// UpdatesFunc[T] is called to update the tag value
+type UpdatesFunc[T any] func(payload T) T
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/int16_tree/tree_v4.go
+++ b/int16_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []int16, nodeIndex uint, matchTag int16, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []int16, nodeIndex uint, matchTag int16, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag int16) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int16, int16) bool { return true },
+		func(int16) int16 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag int16, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag int16, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int16, int16) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag int16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int16, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []int16 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int16_tree/tree_v6_generated.go
+++ b/int16_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag int16, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []int16, nodeIndex uint, matchTag int16, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []int16, nodeIndex uint, matchTag int16, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag int16) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int16, int16) bool { return true },
+		func(int16) int16 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag int16, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag int16, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int16, int16) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag int16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int16, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []int16 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int16_tree/trees.go
+++ b/int16_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload int16, val int16) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload int16) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload int16) int16
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/int32_tree/tree_v4.go
+++ b/int32_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []int32, nodeIndex uint, matchTag int32, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []int32, nodeIndex uint, matchTag int32, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag int32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int32, int32) bool { return true },
+		func(int32) int32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag int32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag int32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int32, int32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag int32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int32, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []int32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int32_tree/tree_v6_generated.go
+++ b/int32_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag int32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []int32, nodeIndex uint, matchTag int32, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []int32, nodeIndex uint, matchTag int32, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag int32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int32, int32) bool { return true },
+		func(int32) int32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag int32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag int32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int32, int32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag int32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int32, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []int32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int32_tree/trees.go
+++ b/int32_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload int32, val int32) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload int32) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload int32) int32
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/int64_tree/tree_v4.go
+++ b/int64_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag int64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag int64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []int64, nodeIndex uint, matchTag int64, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []int64, nodeIndex uint, matchTag int64, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag int64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int64, int64) bool { return true },
+		func(int64) int64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag int64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag int64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int64, int64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag int64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int64, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []int64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int64_tree/tree_v6_generated.go
+++ b/int64_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag int64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag int64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []int64, nodeIndex uint, matchTag int64, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []int64, nodeIndex uint, matchTag int64, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag int64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int64, int64) bool { return true },
+		func(int64) int64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag int64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag int64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int64, int64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag int64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int64, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []int64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int64_tree/trees.go
+++ b/int64_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload int64, val int64) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload int64) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload int64) int64
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/int8_tree/tree_v4.go
+++ b/int8_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []int8, nodeIndex uint, matchTag int8, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []int8, nodeIndex uint, matchTag int8, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag int8) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int8, int8) bool { return true },
+		func(int8) int8 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag int8, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag int8, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int8, int8) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag int8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int8, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []int8 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int8_tree/tree_v6_generated.go
+++ b/int8_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag int8, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []int8, nodeIndex uint, matchTag int8, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []int8, nodeIndex uint, matchTag int8, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag int8) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int8, int8) bool { return true },
+		func(int8) int8 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag int8, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag int8, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int8, int8) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag int8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int8, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []int8 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int8_tree/trees.go
+++ b/int8_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload int8, val int8) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload int8) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload int8) int8
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/int_tree/tree_v4.go
+++ b/int_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []int, nodeIndex uint, matchTag int, matchFunc Ma
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []int, nodeIndex uint, matchTag int, matchFunc Ma
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag int) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int, int) bool { return true },
+		func(int) int { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag int, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag int, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int, int) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag int, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag int, matchFunc MatchesFun
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int_tree/tree_v6_generated.go
+++ b/int_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag int, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []int, nodeIndex uint, matchTag int, matchFunc Ma
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []int, nodeIndex uint, matchTag int, matchFunc Ma
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag int) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(int, int) bool { return true },
+		func(int) int { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag int, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag int, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(int, int) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag int, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag int, matchFunc MatchesFun
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/int_tree/trees.go
+++ b/int_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload int, val int) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload int) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload int) int
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/rune_tree/tree_v4.go
+++ b/rune_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []rune, nodeIndex uint, matchTag rune, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []rune, nodeIndex uint, matchTag rune, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag rune) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(rune, rune) bool { return true },
+		func(rune) rune { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag rune, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag rune, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(rune, rune) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag rune, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag rune, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []rune {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/rune_tree/tree_v6_generated.go
+++ b/rune_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag rune, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []rune, nodeIndex uint, matchTag rune, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []rune, nodeIndex uint, matchTag rune, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag rune) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(rune, rune) bool { return true },
+		func(rune) rune { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag rune, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag rune, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(rune, rune) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag rune, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag rune, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []rune {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/rune_tree/trees.go
+++ b/rune_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload rune, val rune) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload rune) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload rune) rune
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/string_tree/tree_v6_generated.go
+++ b/string_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag string, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag string, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []string, nodeIndex uint, matchTag string, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []string, nodeIndex uint, matchTag string, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag string) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(string, string) bool { return true },
+		func(string) string { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag string, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag string, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(string, string) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag string, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag string, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []string {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/string_tree/trees.go
+++ b/string_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload string, val string) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload string) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload string) string
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/template/tree_v4.go
+++ b/template/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []GeneratedType, nodeIndex uint, matchTag Generat
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []GeneratedType, nodeIndex uint, matchTag Generat
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag GeneratedType) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(GeneratedType, GeneratedType) bool { return true },
+		func(GeneratedType) GeneratedType { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag GeneratedType, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag GeneratedType, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(GeneratedType, GeneratedType) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag GeneratedType, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag GeneratedType, matchFunc 
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []GeneratedType {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/template/tree_v4_test.go
+++ b/template/tree_v4_test.go
@@ -997,6 +997,127 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, "parent", tag)
 }
 
+func TestSetOrUpdate(t *testing.T) {
+	buf := make([]GeneratedType, 0)
+
+	address := ipv4FromBytes([]byte{1, 2, 3, 4}, 32)
+
+	tree := NewTreeV4()
+
+	// add a parent node, just to mix things up
+	countIncreased, count := tree.Set(ipv4FromBytes([]byte{1, 2, 3, 0}, 24), "parent")
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagA",
+		func(GeneratedType) GeneratedType { return "tagZ" })
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+	found, tag := tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagA", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old GeneratedType) GeneratedType { return old.(string) + "B" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagAB", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old GeneratedType) GeneratedType { return old.(string) + "C" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABC", tag)
+
+	countIncreased, count = tree.SetOrUpdate(address, "tagZ",
+		func(old GeneratedType) GeneratedType { return old.(string) + "D" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABCD", tag)
+
+	// now delete the tag
+	delCount := tree.DeleteWithBuffer(buf, address, func(a GeneratedType, b GeneratedType) bool { return true }, "")
+	assert.Equal(t, 1, delCount)
+
+	// verify it's gone - should get the parent
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "parent", tag)
+}
+
+func TestAddOrUpdate(t *testing.T) {
+	buf := make([]GeneratedType, 0)
+
+	address := ipv4FromBytes([]byte{1, 2, 3, 4}, 32)
+
+	tree := NewTreeV4()
+
+	// add a parent node, just to mix things up
+	countIncreased, count := tree.Set(ipv4FromBytes([]byte{1, 2, 3, 0}, 24), "parent")
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagA",
+		nil,
+		func(GeneratedType) GeneratedType { return "tagZ" })
+	assert.True(t, countIncreased)
+	assert.Equal(t, 1, count)
+	found, tag := tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagA", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagZ",
+		func(GeneratedType, GeneratedType) bool { return true },
+		func(old GeneratedType) GeneratedType { return old.(string) + "B" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagAB", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagAB",
+		func(val1 GeneratedType, val2 GeneratedType) bool { return val1 == val2 },
+		func(old GeneratedType) GeneratedType { return old.(string) + "C" })
+	assert.Equal(t, 1, count)
+	assert.False(t, countIncreased)
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "tagABC", tag)
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagABCD",
+		func(val1 GeneratedType, val2 GeneratedType) bool { return val1 == val2 },
+		func(old GeneratedType) GeneratedType { return old.(string) + "Z" })
+	assert.Equal(t, 2, count)
+	assert.True(t, countIncreased)
+	found, tags := tree.FindDeepestTags(address)
+	assert.True(t, found)
+	assert.True(t, tagArraysEqual(tags, []string{"tagABC", "tagABCD"}))
+
+	countIncreased, count = tree.AddOrUpdate(address, "tagABC",
+		func(val1 GeneratedType, val2 GeneratedType) bool { return val1 == val2 },
+		func(old GeneratedType) GeneratedType { return old.(string) + "DE" })
+	assert.Equal(t, 2, count)
+	assert.False(t, countIncreased)
+	found, tags = tree.FindDeepestTags(address)
+	assert.True(t, found)
+	assert.True(t, tagArraysEqual(tags, []string{"tagABCDE", "tagABCD"}))
+
+	// now delete the tag
+	delCount := tree.DeleteWithBuffer(buf, address, func(a GeneratedType, b GeneratedType) bool { return true }, "")
+	assert.Equal(t, 2, delCount)
+
+	// verify it's gone - should get the parent
+	found, tag = tree.FindDeepestTag(address)
+	assert.True(t, found)
+	assert.Equal(t, "parent", tag)
+}
+
 func TestDelete1(t *testing.T) {
 	tags := make([]GeneratedType, 0)
 
@@ -1144,10 +1265,10 @@ func TestTagsMap(t *testing.T) {
 	tree := NewTreeV4()
 
 	// insert tags
-	tree.addTag("tagA", 1, nil, false)
-	tree.addTag("tagB", 1, nil, false)
-	tree.addTag("tagC", 1, nil, false)
-	tree.addTag("tagD", 0, nil, false) // there's no node0, but it exists, so use it for this test
+	tree.addTag("tagA", 1, nil, nil)
+	tree.addTag("tagB", 1, nil, nil)
+	tree.addTag("tagC", 1, nil, nil)
+	tree.addTag("tagD", 0, nil, nil) // there's no node0, but it exists, so use it for this test
 
 	// verify
 	assert.Equal(t, 3, tree.nodes[1].TagCount)

--- a/template/tree_v6_generated.go
+++ b/template/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag GeneratedType, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []GeneratedType, nodeIndex uint, matchTag Generat
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []GeneratedType, nodeIndex uint, matchTag Generat
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag GeneratedType) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(GeneratedType, GeneratedType) bool { return true },
+		func(GeneratedType) GeneratedType { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag GeneratedType, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag GeneratedType, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(GeneratedType, GeneratedType) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag GeneratedType, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag GeneratedType, matchFunc 
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []GeneratedType {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/template/trees.go
+++ b/template/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload GeneratedType, val GeneratedType) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload GeneratedType) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload GeneratedType) GeneratedType
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/uint16_tree/tree_v4.go
+++ b/uint16_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []uint16, nodeIndex uint, matchTag uint16, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []uint16, nodeIndex uint, matchTag uint16, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag uint16) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint16, uint16) bool { return true },
+		func(uint16) uint16 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag uint16, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag uint16, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint16, uint16) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag uint16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint16, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []uint16 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint16_tree/tree_v6_generated.go
+++ b/uint16_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag uint16, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []uint16, nodeIndex uint, matchTag uint16, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []uint16, nodeIndex uint, matchTag uint16, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag uint16) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint16, uint16) bool { return true },
+		func(uint16) uint16 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag uint16, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag uint16, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint16, uint16) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag uint16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint16, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []uint16 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint16_tree/trees.go
+++ b/uint16_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload uint16, val uint16) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload uint16) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload uint16) uint16
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/uint32_tree/tree_v4.go
+++ b/uint32_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []uint32, nodeIndex uint, matchTag uint32, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []uint32, nodeIndex uint, matchTag uint32, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag uint32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint32, uint32) bool { return true },
+		func(uint32) uint32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag uint32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag uint32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint32, uint32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag uint32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint32, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []uint32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint32_tree/tree_v6_generated.go
+++ b/uint32_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag uint32, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []uint32, nodeIndex uint, matchTag uint32, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []uint32, nodeIndex uint, matchTag uint32, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag uint32) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint32, uint32) bool { return true },
+		func(uint32) uint32 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag uint32, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag uint32, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint32, uint32) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag uint32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint32, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []uint32 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint32_tree/trees.go
+++ b/uint32_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload uint32, val uint32) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload uint32) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload uint32) uint32
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/uint64_tree/tree_v4.go
+++ b/uint64_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []uint64, nodeIndex uint, matchTag uint64, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []uint64, nodeIndex uint, matchTag uint64, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag uint64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint64, uint64) bool { return true },
+		func(uint64) uint64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag uint64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag uint64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint64, uint64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag uint64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint64, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []uint64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint64_tree/tree_v6_generated.go
+++ b/uint64_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag uint64, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []uint64, nodeIndex uint, matchTag uint64, matchF
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []uint64, nodeIndex uint, matchTag uint64, matchF
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag uint64) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint64, uint64) bool { return true },
+		func(uint64) uint64 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag uint64, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag uint64, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint64, uint64) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag uint64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint64, matchFunc Matches
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []uint64 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint64_tree/trees.go
+++ b/uint64_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload uint64, val uint64) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload uint64) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload uint64) uint64
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/uint8_tree/tree_v4.go
+++ b/uint8_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []uint8, nodeIndex uint, matchTag uint8, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []uint8, nodeIndex uint, matchTag uint8, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag uint8) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint8, uint8) bool { return true },
+		func(uint8) uint8 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag uint8, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag uint8, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint8, uint8) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag uint8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint8, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []uint8 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint8_tree/tree_v6_generated.go
+++ b/uint8_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag uint8, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []uint8, nodeIndex uint, matchTag uint8, matchFun
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []uint8, nodeIndex uint, matchTag uint8, matchFun
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag uint8) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint8, uint8) bool { return true },
+		func(uint8) uint8 { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag uint8, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag uint8, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint8, uint8) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag uint8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint8, matchFunc MatchesF
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []uint8 {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint8_tree/trees.go
+++ b/uint8_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload uint8, val uint8) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload uint8) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload uint8) uint8
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int

--- a/uint_tree/tree_v4.go
+++ b/uint_tree/tree_v4.go
@@ -51,34 +51,27 @@ func (t *TreeV4) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV4) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV4) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV4) deleteTag(buf []uint, nodeIndex uint, matchTag uint, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV4) deleteTag(buf []uint, nodeIndex uint, matchTag uint, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Set(address patricia.IPv4Address, tag uint) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint, uint) bool { return true },
+		func(uint) uint { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV4) Add(address patricia.IPv4Address, tag uint, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) SetOrUpdate(address patricia.IPv4Address, tag uint, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint, uint) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV4) AddOrUpdate(address patricia.IPv4Address, tag uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV4, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV4) add(address patricia.IPv4Address, tag uint, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV4) Tags() []uint {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV4) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV4) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint_tree/tree_v6_generated.go
+++ b/uint_tree/tree_v6_generated.go
@@ -51,34 +51,27 @@ func (t *TreeV6) CountTags() int {
 	return ret
 }
 
-// add a tag to the node at the input index, storing it in the first position if 'replaceFirst' is true
-// - if matchFunc is non-nil, will enforce uniqueness at this node
+// add a tag to the node at the input index
+// - if matchFunc is non-nil, it is used to determine equality (if nil, no existing tag match)
+// - if udpateFunc is non-nil, it is used to update the tag if it already exists (if nil, the provided tag is used)
 // - returns whether the tag count was increased
-func (t *TreeV6) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, replaceFirst bool) bool {
-	ret := true
-	if replaceFirst {
-		if t.nodes[nodeIndex].TagCount == 0 {
-			t.nodes[nodeIndex].TagCount = 1
-		} else {
-			ret = false
-		}
-		t.tags[(uint64(nodeIndex) << 32)] = tag
-	} else {
-		key := (uint64(nodeIndex) << 32)
-		tagCount := t.nodes[nodeIndex].TagCount
-		if matchFunc != nil {
-			// need to check if this value already exists
-			for i := 0; i < tagCount; i++ {
-				if matchFunc(t.tags[key+uint64(i)], tag) {
-					return false
+func (t *TreeV6) addTag(tag uint, nodeIndex uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) bool {
+	key := (uint64(nodeIndex) << 32)
+	tagCount := t.nodes[nodeIndex].TagCount
+	if matchFunc != nil {
+		// need to check if this value already exists
+		for i := 0; i < tagCount; i++ {
+			if matchFunc(t.tags[key+uint64(i)], tag) {
+				if updateFunc != nil {
+					t.tags[key+(uint64(i))] = updateFunc(t.tags[key+(uint64(i))])
 				}
+				return false
 			}
 		}
-		t.tags[key+(uint64(tagCount))] = tag
-		t.nodes[nodeIndex].TagCount++
-
 	}
-	return ret
+	t.tags[key+(uint64(tagCount))] = tag
+	t.nodes[nodeIndex].TagCount++
+	return true
 }
 
 // return the tags at the input node index - appending to the input slice if they pass the optional filter func
@@ -142,7 +135,7 @@ func (t *TreeV6) deleteTag(buf []uint, nodeIndex uint, matchTag uint, matchFunc 
 			deleteCount++
 		} else {
 			// doesn't match - get to keep it
-			t.addTag(tag, nodeIndex, matchFunc, false)
+			t.addTag(tag, nodeIndex, matchFunc, nil)
 			keepCount++
 		}
 	}
@@ -152,20 +145,37 @@ func (t *TreeV6) deleteTag(buf []uint, nodeIndex uint, matchTag uint, matchFunc 
 // Set the single value for a node - overwrites what's there
 // Returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Set(address patricia.IPv6Address, tag uint) (bool, int) {
-	return t.add(address, tag, nil, true)
+	return t.add(address, tag,
+		func(uint, uint) bool { return true },
+		func(uint) uint { return tag })
 }
 
 // Add adds a tag to the tree
 // - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
 // - returns whether the tag count at this address was increased, and how many tags at this address
 func (t *TreeV6) Add(address patricia.IPv6Address, tag uint, matchFunc MatchesFunc) (bool, int) {
-	return t.add(address, tag, matchFunc, false)
+	return t.add(address, tag, matchFunc, nil)
 }
 
-// add a tag to the tree, optionally as the single value
-// - overwrites the first value in the list if 'replaceFirst' is true
+// SetOrUpdate the single value for a node - overwrites what's there using updateFunc if present
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) SetOrUpdate(address patricia.IPv6Address, tag uint, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag,
+		func(uint, uint) bool { return true },
+		updateFunc)
+}
+
+// AddOrUpdate adds a tag to the tree or update it if it already exists
+// - if matchFunc is non-nil, it will be used to ensure uniqueness at this node
+// - returns whether the tag count at this address was increased, and how many tags at this address
+func (t *TreeV6) AddOrUpdate(address patricia.IPv6Address, tag uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
+	return t.add(address, tag, matchFunc, updateFunc)
+}
+
+// add a tag to the tree, optionally updating the existing value
+// - overwrites the first value in the list if updateFunc function is provided (tag is ignored in this case)
 // - returns whether the tag count was increased, and the number of tags at this address
-func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFunc, replaceFirst bool) (bool, int) {
+func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFunc, updateFunc UpdatesFunc) (bool, int) {
 	// make sure we have more than enough capacity before we start adding to the tree, which invalidates pointers into the array
 	if (len(t.availableIndexes) + cap(t.nodes)) < (len(t.nodes) + 10) {
 		temp := make([]treeNodeV6, len(t.nodes), (cap(t.nodes)+1)*2)
@@ -177,7 +187,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 
 	// handle root tags
 	if address.Length == 0 {
-		countIncreased := t.addTag(tag, 1, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, 1, matchFunc, updateFunc)
 		return countIncreased, t.nodes[1].TagCount
 	}
 
@@ -187,7 +197,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 	if !address.IsLeftBitSet() {
 		if root.Left == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Left = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -195,7 +205,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 	} else {
 		if root.Right == 0 {
 			newNodeIndex := t.newNode(address, address.Length)
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 			root.Right = newNodeIndex
 			return countIncreased, t.nodes[newNodeIndex].TagCount
 		}
@@ -221,14 +231,14 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 
 			if matchCount == node.prefixLength {
 				// the whole prefix matched - we're done!
-				countIncreased := t.addTag(tag, nodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, nodeIndex, matchFunc, updateFunc)
 				return countIncreased, t.nodes[nodeIndex].TagCount
 			}
 
 			// the input address is shorter than the match found - need to create a new, intermediate parent
 			newNodeIndex := t.newNode(address, address.Length)
 			newNode := &t.nodes[newNodeIndex]
-			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+			countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 			// the existing node loses those matching bits, and becomes a child of the new node
 
@@ -263,7 +273,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 				if node.Left == 0 {
 					// nowhere else to go - create a new node here
 					newNodeIndex := t.newNode(address, address.Length)
-					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+					countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 					node.Left = newNodeIndex
 					return countIncreased, t.nodes[newNodeIndex].TagCount
 				}
@@ -278,7 +288,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 			if node.Right == 0 {
 				// nowhere else to go - create a new node here
 				newNodeIndex := t.newNode(address, address.Length)
-				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+				countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 				node.Right = newNodeIndex
 				return countIncreased, t.nodes[newNodeIndex].TagCount
 			}
@@ -297,7 +307,7 @@ func (t *TreeV6) add(address patricia.IPv6Address, tag uint, matchFunc MatchesFu
 		address.ShiftLeft(matchCount)
 
 		newNodeIndex := t.newNode(address, address.Length)
-		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, replaceFirst)
+		countIncreased := t.addTag(tag, newNodeIndex, matchFunc, updateFunc)
 
 		// see where the existing node fits - left or right
 		node.ShiftPrefix(matchCount)
@@ -748,7 +758,7 @@ func (iter *TreeIteratorV6) Tags() []uint {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countNodes(nodeIndex uint) int {
 	nodeCount := 1
 
@@ -763,7 +773,7 @@ func (t *TreeV6) countNodes(nodeIndex uint) int {
 }
 
 // note: this is only used for unit testing
-//nolint
+// nolint
 func (t *TreeV6) countTags(nodeIndex uint) int {
 	node := &t.nodes[nodeIndex]
 

--- a/uint_tree/trees.go
+++ b/uint_tree/trees.go
@@ -10,6 +10,9 @@ type MatchesFunc func(payload uint, val uint) bool
 // FilterFunc is called on each result to see if it belongs in the resulting set
 type FilterFunc func(payload uint) bool
 
+// UpdatesFunc is called to update the tag value
+type UpdatesFunc func(payload uint) uint
+
 // treeIteratorNext is an indicator to know what Next() should return
 // for the current node.
 type treeIteratorNext int


### PR DESCRIPTION
This is useful to avoid a double lookup: once to find the current
value, the second time to update its value. The tag could be a counter
we want to update or, with the generics tree, any struct/map.

The code change is minimal but `Set()` could be a bit smaller since it
reuses the same code path. However, I believe the compiler should be
smart enough to turn the constant function into a single value.