### PR TITLE
Add `Delete*()` methods to iterator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ generics: codegen-generics
 	# Each defined type should be parametrized with T
 	( cd generics_tree && $(SED) -nE 's/^type (\w+).*/\1/p' *.go \
 	        | grep -vFx treeIteratorNext \
+	        | grep -vFx deleteNodeResult \
 		| while read T; do \
 			$(SED) -i -E -e 's/\b'$$T'\b/\0[T]/g' *.go ; \
 			$(SED) -i -E -e 's/\b('$$T')\[T\]/\1[string]/g' *_test.go ; \

--- a/bool_tree/tree_v4.go
+++ b/bool_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []bool, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []bool, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []bool, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []bool, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []bool, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []bool {
-	tags := iter.t.tagsForNode(make([]bool, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []bool) []bool {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal bool) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []bool, matchFunc MatchesFunc, matchVal bool) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/bool_tree/tree_v6_generated.go
+++ b/bool_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []bool, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []bool, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []bool, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []bool, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []bool, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []bool {
-	tags := iter.t.tagsForNode(make([]bool, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []bool) []bool {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal bool) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []bool, matchFunc MatchesFunc, matchVal bool) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/bool_tree/trees.go
+++ b/bool_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/byte_tree/tree_v4.go
+++ b/byte_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []byte, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []byte, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []byte, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []byte, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []byte, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []byte {
-	tags := iter.t.tagsForNode(make([]byte, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []byte) []byte {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal byte) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []byte, matchFunc MatchesFunc, matchVal byte) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/byte_tree/tree_v6_generated.go
+++ b/byte_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []byte, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []byte, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []byte, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []byte, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []byte, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []byte {
-	tags := iter.t.tagsForNode(make([]byte, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []byte) []byte {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal byte) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []byte, matchFunc MatchesFunc, matchVal byte) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/byte_tree/trees.go
+++ b/byte_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/complex128_tree/tree_v4.go
+++ b/complex128_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex128, address patricia.IPv4Address
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex128, address patricia.IPv4Address
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex128, address patricia.IPv4Address
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex128, address patricia.IPv4Address
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex128, address patricia.IPv4Address
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []complex128 {
-	tags := iter.t.tagsForNode(make([]complex128, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []complex128) []complex128 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal complex128) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []complex128, matchFunc MatchesFunc, matchVal complex128) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/complex128_tree/tree_v6_generated.go
+++ b/complex128_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex128, address patricia.IPv6Address
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex128, address patricia.IPv6Address
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex128, address patricia.IPv6Address
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex128, address patricia.IPv6Address
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex128, address patricia.IPv6Address
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []complex128 {
-	tags := iter.t.tagsForNode(make([]complex128, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []complex128) []complex128 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal complex128) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []complex128, matchFunc MatchesFunc, matchVal complex128) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/complex128_tree/trees.go
+++ b/complex128_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/complex64_tree/tree_v4.go
+++ b/complex64_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex64, address patricia.IPv4Address,
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex64, address patricia.IPv4Address,
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex64, address patricia.IPv4Address,
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex64, address patricia.IPv4Address,
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []complex64, address patricia.IPv4Address,
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []complex64 {
-	tags := iter.t.tagsForNode(make([]complex64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []complex64) []complex64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal complex64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []complex64, matchFunc MatchesFunc, matchVal complex64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/complex64_tree/tree_v6_generated.go
+++ b/complex64_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex64, address patricia.IPv6Address,
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex64, address patricia.IPv6Address,
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex64, address patricia.IPv6Address,
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex64, address patricia.IPv6Address,
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []complex64, address patricia.IPv6Address,
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []complex64 {
-	tags := iter.t.tagsForNode(make([]complex64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []complex64) []complex64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal complex64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []complex64, matchFunc MatchesFunc, matchVal complex64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/complex64_tree/trees.go
+++ b/complex64_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/float32_tree/tree_v4.go
+++ b/float32_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []float32, address patricia.IPv4Address, m
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float32, address patricia.IPv4Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []float32, address patricia.IPv4Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float32, address patricia.IPv4Address, m
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float32, address patricia.IPv4Address, m
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []float32 {
-	tags := iter.t.tagsForNode(make([]float32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []float32) []float32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal float32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []float32, matchFunc MatchesFunc, matchVal float32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/float32_tree/tree_v6_generated.go
+++ b/float32_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []float32, address patricia.IPv6Address, m
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float32, address patricia.IPv6Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []float32, address patricia.IPv6Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float32, address patricia.IPv6Address, m
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float32, address patricia.IPv6Address, m
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []float32 {
-	tags := iter.t.tagsForNode(make([]float32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []float32) []float32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal float32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []float32, matchFunc MatchesFunc, matchVal float32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/float32_tree/trees.go
+++ b/float32_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/float64_tree/tree_v4.go
+++ b/float64_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []float64, address patricia.IPv4Address, m
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float64, address patricia.IPv4Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []float64, address patricia.IPv4Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float64, address patricia.IPv4Address, m
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []float64, address patricia.IPv4Address, m
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []float64 {
-	tags := iter.t.tagsForNode(make([]float64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []float64) []float64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal float64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []float64, matchFunc MatchesFunc, matchVal float64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/float64_tree/tree_v6_generated.go
+++ b/float64_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []float64, address patricia.IPv6Address, m
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float64, address patricia.IPv6Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []float64, address patricia.IPv6Address, m
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float64, address patricia.IPv6Address, m
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []float64, address patricia.IPv6Address, m
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []float64 {
-	tags := iter.t.tagsForNode(make([]float64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []float64) []float64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal float64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []float64, matchFunc MatchesFunc, matchVal float64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/float64_tree/trees.go
+++ b/float64_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/generics_tree/tree_v4.go
+++ b/generics_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4[T]) DeleteWithBuffer(buf []T, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4[T]) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4[T], parentIndex uint, parent *treeNodeV4[T]) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4[T]) DeleteWithBuffer(buf []T, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4[T]) DeleteWithBuffer(buf []T, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4[T]) DeleteWithBuffer(buf []T, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4[T]) DeleteWithBuffer(buf []T, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4[T]) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4[T]) Tags() []T {
-	tags := iter.t.tagsForNode(make([]T, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4[T]) TagsWithBuffer(ret []T) []T {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4[T]) Delete(matchFunc MatchesFunc[T], matchVal T) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4[T]) DeleteWithBuffer(buf []T, matchFunc MatchesFunc[T], matchVal T) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/generics_tree/tree_v4_test.go
+++ b/generics_tree/tree_v4_test.go
@@ -1299,3 +1299,185 @@ func TestIterateV4(t *testing.T) {
 	}
 	assert.Equal(t, expected, got)
 }
+
+// test deletion during tree traversal
+func TestIterateAndDeleteV4(t *testing.T) {
+	tree := NewTreeV4[string]()
+
+	compare := func(expected [][]string) {
+		t.Helper()
+		got := [][]string{}
+		iter := tree.Iterate()
+		for iter.Next() {
+			tags := []string{}
+			for _, s := range iter.Tags() { //nolint:gosimple
+				tags = append(tags, s)
+			}
+			got = append(got, append([]string{iter.Address().String()}, tags...))
+		}
+		assert.Equal(t, expected, got)
+	}
+
+	ipA := ipv4FromBytes([]byte{203, 143, 220, 0}, 23)
+	ipB := ipv4FromBytes([]byte{203, 143, 220, 198}, 31)
+	ipC := ipv4FromBytes([]byte{203, 143, 0, 0}, 16)
+	ipD := ipv4FromBytes([]byte{203, 143, 221, 75}, 32)
+	ipE := ipv4FromBytes([]byte{203, 143, 220, 198}, 32)
+
+	tree.Add(ipA, "A", nil)
+	tree.Add(ipB, "B", nil)
+	tree.Add(ipC, "C", nil)
+	tree.Add(ipD, "D1", nil)
+	tree.Add(ipD, "D2", nil)
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.0/23", "A"},
+		{"203.143.220.198/31", "B"},
+		{"203.143.221.75/32", "D1", "D2"},
+	})
+
+	// Delete one tag, no node
+	iter := tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "D1"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.0/23", "A"},
+		{"203.143.220.198/31", "B"},
+		{"203.143.221.75/32", "D2"},
+	})
+
+	// Delete a node with two children
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "A"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.198/31", "B"},
+		{"203.143.221.75/32", "D2"},
+	})
+
+	// Delete right children of a node two children
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "D2"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.198/31", "B"},
+	})
+
+	// Delete leaf
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "B"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+	})
+
+	// Delete root
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "C"
+		}, "")
+	}
+	compare([][]string{})
+
+	// Delete a node with a left children only
+	tree = NewTreeV4[string]()
+	tree.Add(ipA, "A", nil)
+	tree.Add(ipB, "B", nil)
+	tree.Add(ipC, "C", nil)
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "A"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.198/31", "B"},
+	})
+
+	// Delete a node with a right children only
+	tree = NewTreeV4[string]()
+	tree.Add(ipA, "A", nil)
+	tree.Add(ipC, "C", nil)
+	tree.Add(ipD, "D", nil)
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "A"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.221.75/32", "D"},
+	})
+
+	// Delete a node without children and at the left of its empty parent
+	tree = NewTreeV4[string]()
+	tree.Add(ipB, "B", nil)
+	tree.Add(ipC, "C", nil)
+	tree.Add(ipD, "D", nil)
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "B"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.221.75/32", "D"},
+	})
+
+	// Delete left node while a right node is present
+	tree = NewTreeV4[string]()
+	tree.Add(ipA, "A", nil)
+	tree.Add(ipB, "B", nil)
+	tree.Add(ipC, "C", nil)
+	tree.Add(ipD, "D", nil)
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "B"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.0/23", "A"},
+		{"203.143.221.75/32", "D"},
+	})
+
+	// Delete left node with a child
+	tree = NewTreeV4[string]()
+	tree.Add(ipA, "A", nil)
+	tree.Add(ipB, "B", nil)
+	tree.Add(ipC, "C", nil)
+	tree.Add(ipD, "D", nil)
+	tree.Add(ipE, "E", nil)
+	iter = tree.Iterate()
+	for iter.Next() {
+		iter.Delete(func(payload, val string) bool {
+			return payload == "B"
+		}, "")
+	}
+	compare([][]string{
+		{"203.143.0.0/16", "C"},
+		{"203.143.220.0/23", "A"},
+		{"203.143.220.198/32", "E"},
+		{"203.143.221.75/32", "D"},
+	})
+}

--- a/generics_tree/tree_v6_generated.go
+++ b/generics_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6[T]) DeleteWithBuffer(buf []T, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6[T]) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6[T], parentIndex uint, parent *treeNodeV6[T]) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6[T]) DeleteWithBuffer(buf []T, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6[T]) DeleteWithBuffer(buf []T, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6[T]) DeleteWithBuffer(buf []T, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6[T]) DeleteWithBuffer(buf []T, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6[T]) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6[T]) Tags() []T {
-	tags := iter.t.tagsForNode(make([]T, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6[T]) TagsWithBuffer(ret []T) []T {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6[T]) Delete(matchFunc MatchesFunc[T], matchVal T) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6[T]) DeleteWithBuffer(buf []T, matchFunc MatchesFunc[T], matchVal T) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/generics_tree/trees.go
+++ b/generics_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/int16_tree/tree_v4.go
+++ b/int16_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []int16, address patricia.IPv4Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int16, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []int16, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int16, address patricia.IPv4Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int16, address patricia.IPv4Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []int16 {
-	tags := iter.t.tagsForNode(make([]int16, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []int16) []int16 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal int16) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []int16, matchFunc MatchesFunc, matchVal int16) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int16_tree/tree_v6_generated.go
+++ b/int16_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []int16, address patricia.IPv6Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int16, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []int16, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int16, address patricia.IPv6Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int16, address patricia.IPv6Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []int16 {
-	tags := iter.t.tagsForNode(make([]int16, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []int16) []int16 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal int16) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []int16, matchFunc MatchesFunc, matchVal int16) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int16_tree/trees.go
+++ b/int16_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/int32_tree/tree_v4.go
+++ b/int32_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []int32, address patricia.IPv4Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int32, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []int32, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int32, address patricia.IPv4Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int32, address patricia.IPv4Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []int32 {
-	tags := iter.t.tagsForNode(make([]int32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []int32) []int32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal int32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []int32, matchFunc MatchesFunc, matchVal int32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int32_tree/tree_v6_generated.go
+++ b/int32_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []int32, address patricia.IPv6Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int32, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []int32, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int32, address patricia.IPv6Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int32, address patricia.IPv6Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []int32 {
-	tags := iter.t.tagsForNode(make([]int32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []int32) []int32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal int32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []int32, matchFunc MatchesFunc, matchVal int32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int32_tree/trees.go
+++ b/int32_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/int64_tree/tree_v4.go
+++ b/int64_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []int64, address patricia.IPv4Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int64, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []int64, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int64, address patricia.IPv4Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int64, address patricia.IPv4Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []int64 {
-	tags := iter.t.tagsForNode(make([]int64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []int64) []int64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal int64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []int64, matchFunc MatchesFunc, matchVal int64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int64_tree/trees.go
+++ b/int64_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/int8_tree/tree_v4.go
+++ b/int8_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []int8, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int8, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []int8, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int8, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int8, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []int8 {
-	tags := iter.t.tagsForNode(make([]int8, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []int8) []int8 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal int8) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []int8, matchFunc MatchesFunc, matchVal int8) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int8_tree/tree_v6_generated.go
+++ b/int8_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []int8, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int8, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []int8, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int8, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int8, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []int8 {
-	tags := iter.t.tagsForNode(make([]int8, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []int8) []int8 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal int8) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []int8, matchFunc MatchesFunc, matchVal int8) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int8_tree/trees.go
+++ b/int8_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/int_tree/tree_v4.go
+++ b/int_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []int, address patricia.IPv4Address, match
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int, address patricia.IPv4Address, match
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []int, address patricia.IPv4Address, match
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int, address patricia.IPv4Address, match
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []int, address patricia.IPv4Address, match
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []int {
-	tags := iter.t.tagsForNode(make([]int, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []int) []int {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal int) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []int, matchFunc MatchesFunc, matchVal int) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int_tree/tree_v6_generated.go
+++ b/int_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []int, address patricia.IPv6Address, match
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int, address patricia.IPv6Address, match
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []int, address patricia.IPv6Address, match
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int, address patricia.IPv6Address, match
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []int, address patricia.IPv6Address, match
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []int {
-	tags := iter.t.tagsForNode(make([]int, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []int) []int {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal int) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []int, matchFunc MatchesFunc, matchVal int) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/int_tree/trees.go
+++ b/int_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/rune_tree/tree_v4.go
+++ b/rune_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []rune, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []rune, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []rune, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []rune, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []rune, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []rune {
-	tags := iter.t.tagsForNode(make([]rune, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []rune) []rune {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal rune) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []rune, matchFunc MatchesFunc, matchVal rune) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/rune_tree/tree_v6_generated.go
+++ b/rune_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []rune, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []rune, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []rune, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []rune, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []rune, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []rune {
-	tags := iter.t.tagsForNode(make([]rune, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []rune) []rune {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal rune) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []rune, matchFunc MatchesFunc, matchVal rune) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/rune_tree/trees.go
+++ b/rune_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/string_tree/tree_v4.go
+++ b/string_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []string, address patricia.IPv4Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []string, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []string, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []string, address patricia.IPv4Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []string, address patricia.IPv4Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []string {
-	tags := iter.t.tagsForNode(make([]string, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []string) []string {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal string) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []string, matchFunc MatchesFunc, matchVal string) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/string_tree/tree_v6_generated.go
+++ b/string_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []string, address patricia.IPv6Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []string, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []string, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []string, address patricia.IPv6Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []string, address patricia.IPv6Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []string {
-	tags := iter.t.tagsForNode(make([]string, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []string) []string {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal string) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []string, matchFunc MatchesFunc, matchVal string) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/string_tree/trees.go
+++ b/string_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/template/tree_v4.go
+++ b/template/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv4Addr
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv4Addr
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv4Addr
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv4Addr
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv4Addr
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []GeneratedType {
-	tags := iter.t.tagsForNode(make([]GeneratedType, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []GeneratedType) []GeneratedType {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal GeneratedType) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []GeneratedType, matchFunc MatchesFunc, matchVal GeneratedType) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/template/tree_v6_generated.go
+++ b/template/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv6Addr
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv6Addr
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv6Addr
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv6Addr
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []GeneratedType, address patricia.IPv6Addr
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []GeneratedType {
-	tags := iter.t.tagsForNode(make([]GeneratedType, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []GeneratedType) []GeneratedType {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal GeneratedType) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []GeneratedType, matchFunc MatchesFunc, matchVal GeneratedType) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/template/trees.go
+++ b/template/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/uint16_tree/tree_v4.go
+++ b/uint16_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint16, address patricia.IPv4Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint16, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint16, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint16, address patricia.IPv4Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint16, address patricia.IPv4Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []uint16 {
-	tags := iter.t.tagsForNode(make([]uint16, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint16) []uint16 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal uint16) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []uint16, matchFunc MatchesFunc, matchVal uint16) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint16_tree/tree_v6_generated.go
+++ b/uint16_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint16, address patricia.IPv6Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint16, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint16, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint16, address patricia.IPv6Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint16, address patricia.IPv6Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []uint16 {
-	tags := iter.t.tagsForNode(make([]uint16, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint16) []uint16 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal uint16) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []uint16, matchFunc MatchesFunc, matchVal uint16) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint16_tree/trees.go
+++ b/uint16_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/uint32_tree/tree_v4.go
+++ b/uint32_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint32, address patricia.IPv4Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint32, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint32, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint32, address patricia.IPv4Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint32, address patricia.IPv4Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []uint32 {
-	tags := iter.t.tagsForNode(make([]uint32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint32) []uint32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal uint32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []uint32, matchFunc MatchesFunc, matchVal uint32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint32_tree/tree_v6_generated.go
+++ b/uint32_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint32, address patricia.IPv6Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint32, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint32, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint32, address patricia.IPv6Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint32, address patricia.IPv6Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []uint32 {
-	tags := iter.t.tagsForNode(make([]uint32, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint32) []uint32 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal uint32) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []uint32, matchFunc MatchesFunc, matchVal uint32) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint32_tree/trees.go
+++ b/uint32_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/uint64_tree/tree_v4.go
+++ b/uint64_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint64, address patricia.IPv4Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint64, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint64, address patricia.IPv4Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint64, address patricia.IPv4Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint64, address patricia.IPv4Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []uint64 {
-	tags := iter.t.tagsForNode(make([]uint64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint64) []uint64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal uint64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []uint64, matchFunc MatchesFunc, matchVal uint64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint64_tree/tree_v6_generated.go
+++ b/uint64_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint64, address patricia.IPv6Address, ma
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint64, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint64, address patricia.IPv6Address, ma
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint64, address patricia.IPv6Address, ma
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint64, address patricia.IPv6Address, ma
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []uint64 {
-	tags := iter.t.tagsForNode(make([]uint64, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint64) []uint64 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal uint64) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []uint64, matchFunc MatchesFunc, matchVal uint64) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint64_tree/trees.go
+++ b/uint64_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/uint8_tree/tree_v4.go
+++ b/uint8_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint8, address patricia.IPv4Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint8, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint8, address patricia.IPv4Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint8, address patricia.IPv4Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint8, address patricia.IPv4Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []uint8 {
-	tags := iter.t.tagsForNode(make([]uint8, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint8) []uint8 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal uint8) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []uint8, matchFunc MatchesFunc, matchVal uint8) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint8_tree/tree_v6_generated.go
+++ b/uint8_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint8, address patricia.IPv6Address, mat
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint8, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint8, address patricia.IPv6Address, mat
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint8, address patricia.IPv6Address, mat
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint8, address patricia.IPv6Address, mat
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []uint8 {
-	tags := iter.t.tagsForNode(make([]uint8, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint8) []uint8 {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal uint8) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []uint8, matchFunc MatchesFunc, matchVal uint8) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint8_tree/trees.go
+++ b/uint8_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)

--- a/uint_tree/tree_v4.go
+++ b/uint_tree/tree_v4.go
@@ -396,18 +396,25 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint, address patricia.IPv4Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV4) deleteNode(targetNodeIndex uint, targetNode *treeNodeV4, parentIndex uint, parent *treeNodeV4) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint, address patricia.IPv4Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint, address patricia.IPv4Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV4) DeleteWithBuffer(buf []uint, address patricia.IPv4Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV4) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV4) Tags() []uint {
-	tags := iter.t.tagsForNode(make([]uint, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint) []uint {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV4) Delete(matchFunc MatchesFunc, matchVal uint) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV4) DeleteWithBuffer(buf []uint, matchFunc MatchesFunc, matchVal uint) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint_tree/tree_v6_generated.go
+++ b/uint_tree/tree_v6_generated.go
@@ -396,18 +396,25 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint, address patricia.IPv6Address, matc
 		// target node still has tags - we're not deleting it
 		return deleteCount
 	}
+	t.deleteNode(targetNodeIndex, targetNode, parentIndex, parent)
+	return deleteCount
+}
 
+// deleteNode removes the provided node and compact the tree.
+func (t *TreeV6) deleteNode(targetNodeIndex uint, targetNode *treeNodeV6, parentIndex uint, parent *treeNodeV6) (result deleteNodeResult) {
+	result = notDeleted
 	if targetNodeIndex == 1 {
 		// can't delete the root node
-		return deleteCount
+		return result
 	}
 
 	// compact the tree, if possible
 	if targetNode.Left != 0 && targetNode.Right != 0 {
 		// target has two children - nothing we can do - not deleting the node
-		return deleteCount
+		return result
 	} else if targetNode.Left != 0 {
 		// target node only has only left child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Left
 		} else {
@@ -419,6 +426,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else if targetNode.Right != 0 {
 		// target node has only right child
+		result = deletedNodeReplacedByChild
 		if parent.Left == targetNodeIndex {
 			parent.Left = targetNode.Right
 		} else {
@@ -430,10 +438,12 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint, address patricia.IPv6Address, matc
 		tmpNode.MergeFromNodes(targetNode, tmpNode)
 	} else {
 		// target node has no children - straight-up remove this node
+		result = deletedNodeJustRemoved
 		if parent.Left == targetNodeIndex {
 			parent.Left = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Right != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Right
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -451,6 +461,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint, address patricia.IPv6Address, matc
 			parent.Right = 0
 			if parentIndex > 1 && parent.TagCount == 0 && parent.Left != 0 {
 				// parent isn't root, has no tags, and there's a sibling - merge sibling into parent
+				result = deletedNodeParentReplacedBySibling
 				siblingIndexToDelete := parent.Left
 				tmpNode := &t.nodes[siblingIndexToDelete]
 				parent.MergeFromNodes(parent, tmpNode)
@@ -470,7 +481,7 @@ func (t *TreeV6) DeleteWithBuffer(buf []uint, address patricia.IPv6Address, matc
 	targetNode.Left = 0
 	targetNode.Right = 0
 	t.availableIndexes = append(t.availableIndexes, targetNodeIndex)
-	return deleteCount
+	return result
 }
 
 // FindTagsWithFilter finds all matching tags that passes the filter function
@@ -740,11 +751,77 @@ func (iter *TreeIteratorV6) Next() bool {
 	}
 }
 
-// Tags return the current tags for the iterator. This is not a copy
+// Tags returns the current tags for the iterator. This is not a copy
 // and the result should not be used outside the iterator.
 func (iter *TreeIteratorV6) Tags() []uint {
-	tags := iter.t.tagsForNode(make([]uint, 0), uint(iter.nodeIndex), nil)
-	return tags
+	return iter.TagsWithBuffer(nil)
+}
+
+// TagsWithBuffer returns the current tags for the iterator. To avoid
+// allocation, it uses the provided buffer.
+func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint) []uint {
+	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
+}
+
+// Delete a tag from the current node if it matches matchVal, as
+// determined by matchFunc. Returns how many tags are removed
+// - use DeleteWithBuffer if you can reuse slices, to cut down on allocations
+func (iter *TreeIteratorV6) Delete(matchFunc MatchesFunc, matchVal uint) int {
+	return iter.DeleteWithBuffer(nil, matchFunc, matchVal)
+}
+
+// DeleteWithBuffer a tag from the current node if it matches
+// matchVal, as determined by matchFunc. Returns how many tags are
+// removed
+// - uses input slice to reduce allocations
+func (iter *TreeIteratorV6) DeleteWithBuffer(buf []uint, matchFunc MatchesFunc, matchVal uint) int {
+	deleteCount, remainingTagCount := iter.t.deleteTag(buf, iter.nodeIndex, matchVal, matchFunc)
+	if remainingTagCount > 0 || iter.nodeIndex == 1 {
+		return deleteCount
+	}
+	nodeHistoryLen := len(iter.nodeHistory)
+	currentIndex := iter.nodeIndex
+	current := &iter.t.nodes[currentIndex]
+	parentIndex := iter.nodeHistory[nodeHistoryLen-1]
+	parent := &iter.t.nodes[parentIndex]
+	wasLeft := false
+	if parent.Left == currentIndex {
+		wasLeft = true
+	}
+	result := iter.t.deleteNode(currentIndex, current, parentIndex, parent)
+	switch result {
+	case notDeleted:
+		return deleteCount
+	case deletedNodeReplacedByChild:
+		// Continue with the child
+		if wasLeft {
+			iter.nodeIndex = parent.Left
+		} else {
+			iter.nodeIndex = parent.Right
+		}
+		iter.next = nextSelf
+	case deletedNodeParentReplacedBySibling:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Parent replaced by right sibling, to visit
+			iter.next = nextSelf
+		} else {
+			// Parent replaced by left sibling, already visited
+			iter.next = nextUp
+		}
+	case deletedNodeJustRemoved:
+		iter.nodeIndex = parentIndex
+		iter.nodeHistory = iter.nodeHistory[:nodeHistoryLen-1]
+		if wasLeft {
+			// Visit our sibling
+			iter.next = nextRight
+		} else {
+			// Go up
+			iter.next = nextUp
+		}
+	}
+	return deleteCount
 }
 
 // note: this is only used for unit testing

--- a/uint_tree/trees.go
+++ b/uint_tree/trees.go
@@ -20,3 +20,13 @@ const (
 	nextRight
 	nextUp
 )
+
+// deleteNodeResult is the return type for deleteNode() function
+type deleteNodeResult int
+
+const (
+	notDeleted deleteNodeResult = iota
+	deletedNodeReplacedByChild
+	deletedNodeParentReplacedBySibling
+	deletedNodeJustRemoved
+)


### PR DESCRIPTION
This is useful to remove tags matching a certain criteria in the whole tree. For example, when implementing a RIB, we may want to remove tags associated with a down peer.

The tree compaction is extracted into its own function and returns an hint on how compaction was done. This hint is then used by the `Delete*()` functions to update the current iterator.