### PR TITLE
Add TagsFromRoot

### DIFF
--- a/bool_tree/tree_v4.go
+++ b/bool_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []bool) []bool {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]bool {
+	ret := make([][]bool, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/bool_tree/tree_v6_generated.go
+++ b/bool_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []bool) []bool {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]bool {
+	ret := make([][]bool, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/byte_tree/tree_v4.go
+++ b/byte_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []byte) []byte {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]byte {
+	ret := make([][]byte, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/byte_tree/tree_v6_generated.go
+++ b/byte_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []byte) []byte {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]byte {
+	ret := make([][]byte, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/complex128_tree/tree_v4.go
+++ b/complex128_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []complex128) []complex128 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]complex128 {
+	ret := make([][]complex128, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/complex128_tree/tree_v6_generated.go
+++ b/complex128_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []complex128) []complex128 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]complex128 {
+	ret := make([][]complex128, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/complex64_tree/tree_v4.go
+++ b/complex64_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []complex64) []complex64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]complex64 {
+	ret := make([][]complex64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/complex64_tree/tree_v6_generated.go
+++ b/complex64_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []complex64) []complex64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]complex64 {
+	ret := make([][]complex64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/float32_tree/tree_v4.go
+++ b/float32_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []float32) []float32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]float32 {
+	ret := make([][]float32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/float32_tree/tree_v6_generated.go
+++ b/float32_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []float32) []float32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]float32 {
+	ret := make([][]float32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/float64_tree/tree_v4.go
+++ b/float64_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []float64) []float64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]float64 {
+	ret := make([][]float64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/float64_tree/tree_v6_generated.go
+++ b/float64_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []float64) []float64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]float64 {
+	ret := make([][]float64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/generics_tree/tree_v4.go
+++ b/generics_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4[T]) TagsWithBuffer(ret []T) []T {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4[T]) TagsFromRoot() [][]T {
+	ret := make([][]T, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/generics_tree/tree_v6_generated.go
+++ b/generics_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6[T]) TagsWithBuffer(ret []T) []T {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6[T]) TagsFromRoot() [][]T {
+	ret := make([][]T, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int16_tree/tree_v4.go
+++ b/int16_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []int16) []int16 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]int16 {
+	ret := make([][]int16, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int16_tree/tree_v6_generated.go
+++ b/int16_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []int16) []int16 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]int16 {
+	ret := make([][]int16, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int32_tree/tree_v4.go
+++ b/int32_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []int32) []int32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]int32 {
+	ret := make([][]int32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int32_tree/tree_v6_generated.go
+++ b/int32_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []int32) []int32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]int32 {
+	ret := make([][]int32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int64_tree/tree_v4.go
+++ b/int64_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []int64) []int64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]int64 {
+	ret := make([][]int64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int64_tree/tree_v6_generated.go
+++ b/int64_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []int64) []int64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]int64 {
+	ret := make([][]int64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int8_tree/tree_v4.go
+++ b/int8_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []int8) []int8 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]int8 {
+	ret := make([][]int8, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int8_tree/tree_v6_generated.go
+++ b/int8_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []int8) []int8 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]int8 {
+	ret := make([][]int8, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int_tree/tree_v4.go
+++ b/int_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []int) []int {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]int {
+	ret := make([][]int, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/int_tree/tree_v6_generated.go
+++ b/int_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []int) []int {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]int {
+	ret := make([][]int, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/rune_tree/tree_v4.go
+++ b/rune_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []rune) []rune {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]rune {
+	ret := make([][]rune, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/rune_tree/tree_v6_generated.go
+++ b/rune_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []rune) []rune {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]rune {
+	ret := make([][]rune, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/string_tree/tree_v4.go
+++ b/string_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []string) []string {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]string {
+	ret := make([][]string, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/string_tree/tree_v6_generated.go
+++ b/string_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []string) []string {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]string {
+	ret := make([][]string, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/template/tree_v4.go
+++ b/template/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []GeneratedType) []GeneratedType 
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]GeneratedType {
+	ret := make([][]GeneratedType, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/template/tree_v4_test.go
+++ b/template/tree_v4_test.go
@@ -1415,9 +1415,9 @@ func TestIterateV4(t *testing.T) {
 	tree.Add(ipD, "D2", nil)
 
 	expected := map[string][]string{
+		"203.143.0.0/16":     {"C"},
 		"203.143.220.0/23":   {"A"},
 		"203.143.220.198/32": {"B"},
-		"203.143.0.0/16":     {"C"},
 		"203.143.221.75/32":  {"D1", "D2"},
 	}
 	got := map[string][]string{}
@@ -1430,6 +1430,27 @@ func TestIterateV4(t *testing.T) {
 		got[iter.Address().String()] = tags
 	}
 	assert.Equal(t, expected, got)
+
+	expectedFromRoot := map[string][][]string{
+		"203.143.220.0/23":   {{}, {"C"}, {"A"}},
+		"203.143.220.198/32": {{}, {"C"}, {"A"}, {"B"}},
+		"203.143.0.0/16":     {{}, {"C"}},
+		"203.143.221.75/32":  {{}, {"C"}, {"A"}, {"D1", "D2"}},
+	}
+	gotFromRoot := map[string][][]string{}
+	iter = tree.Iterate()
+	for iter.Next() {
+		tags := iter.TagsFromRoot()
+		tagsValues := make([][]string, len(tags))
+		for i, tagList := range tags { //nolint:gosimple
+			tagsValues[i] = []string{}
+			for _, t := range tagList {
+				tagsValues[i] = append(tagsValues[i], t.(string))
+			}
+		}
+		gotFromRoot[iter.Address().String()] = tagsValues
+	}
+	assert.Equal(t, expectedFromRoot, gotFromRoot)
 }
 
 // test deletion during tree traversal

--- a/template/tree_v6_generated.go
+++ b/template/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []GeneratedType) []GeneratedType 
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]GeneratedType {
+	ret := make([][]GeneratedType, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/template/tree_v6_test.go
+++ b/template/tree_v6_test.go
@@ -472,4 +472,25 @@ func TestIterateV6(t *testing.T) {
 		got[iter.Address().String()] = tags
 	}
 	assert.Equal(t, expected, got)
+
+	expectedFromRoot := map[string][][]string{
+		"2001:db8::cb8f:dc00/119": {{}, {"C"}, {"A"}},
+		"2001:db8::cb8f:dcc6/128": {{}, {"C"}, {"A"}, {"B"}},
+		"2001:db8::cb8f:0/112":    {{}, {"C"}},
+		"2001:db8::cb8f:dd4b/128": {{}, {"C"}, {"A"}, {"D1", "D2"}},
+	}
+	gotFromRoot := map[string][][]string{}
+	iter = tree.Iterate()
+	for iter.Next() {
+		tags := iter.TagsFromRoot()
+		tagsValues := make([][]string, len(tags))
+		for i, tagList := range tags { //nolint:gosimple
+			tagsValues[i] = []string{}
+			for _, t := range tagList {
+				tagsValues[i] = append(tagsValues[i], t.(string))
+			}
+		}
+		gotFromRoot[iter.Address().String()] = tagsValues
+	}
+	assert.Equal(t, expectedFromRoot, gotFromRoot)
 }

--- a/uint16_tree/tree_v4.go
+++ b/uint16_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint16) []uint16 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]uint16 {
+	ret := make([][]uint16, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint16_tree/tree_v6_generated.go
+++ b/uint16_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint16) []uint16 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]uint16 {
+	ret := make([][]uint16, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint32_tree/tree_v4.go
+++ b/uint32_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint32) []uint32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]uint32 {
+	ret := make([][]uint32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint32_tree/tree_v6_generated.go
+++ b/uint32_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint32) []uint32 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]uint32 {
+	ret := make([][]uint32, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint64_tree/tree_v4.go
+++ b/uint64_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint64) []uint64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]uint64 {
+	ret := make([][]uint64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint64_tree/tree_v6_generated.go
+++ b/uint64_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint64) []uint64 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]uint64 {
+	ret := make([][]uint64, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint8_tree/tree_v4.go
+++ b/uint8_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint8) []uint8 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]uint8 {
+	ret := make([][]uint8, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint8_tree/tree_v6_generated.go
+++ b/uint8_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint8) []uint8 {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]uint8 {
+	ret := make([][]uint8, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint_tree/tree_v4.go
+++ b/uint_tree/tree_v4.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV4) TagsWithBuffer(ret []uint) []uint {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV4) TagsFromRoot() [][]uint {
+	ret := make([][]uint, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations

--- a/uint_tree/tree_v6_generated.go
+++ b/uint_tree/tree_v6_generated.go
@@ -788,6 +788,19 @@ func (iter *TreeIteratorV6) TagsWithBuffer(ret []uint) []uint {
 	return iter.t.tagsForNode(ret, uint(iter.nodeIndex), nil)
 }
 
+// TagsFromRoot returns the list of all tags from
+// the root of the tree to the current node for the iterator.
+// This is not a copy
+// and the result should not be used outside the iterator.
+func (iter *TreeIteratorV6) TagsFromRoot() [][]uint {
+	ret := make([][]uint, len(iter.nodeHistory)+1)
+	for i, n := range iter.nodeHistory {
+		ret[i] = iter.t.tagsForNode(nil, uint(n), nil)
+	}
+	ret[len(iter.nodeHistory)] = iter.t.tagsForNode(nil, uint(iter.nodeIndex), nil)
+	return ret
+}
+
 // Delete a tag from the current node if it matches matchVal, as
 // determined by matchFunc. Returns how many tags are removed
 // - use DeleteWithBuffer if you can reuse slices, to cut down on allocations


### PR DESCRIPTION
Add a method to the tree iterator that
returns all tags from all the node from the root of the tree to the current leaf, in that order.

This is usefull to find the most relevant tag, when it's not defined on the node itself. Similar to FindDeepestTags, but for iter.